### PR TITLE
made test output not enabled by default to keep it clean. \Uncomment …

### DIFF
--- a/sandbox_tests/src/api_tests.rs
+++ b/sandbox_tests/src/api_tests.rs
@@ -31,12 +31,16 @@ use configuration_service::config_api::{PublicConfigApi, PrivateConfigApi,
                                         ApiResponseVotePost};
 
 use blockchain_explorer::api::Api;
-use blockchain_explorer::helpers::init_logger;
+#[allow(unused_imports)]
+use blockchain_explorer::helpers;
 
 use sandbox::sandbox::{sandbox_with_services, Sandbox};
 use sandbox::sandbox_tests_helper::{add_one_height_with_transactions, SandboxState};
 use super::generate_config_with_message;
 
+fn init_logger() {
+    //let _ = helpers::init_logger();
+}
 fn response_body(response: Response) -> serde_json::Value {
     if let Some(mut body) = response.body {
         let mut buf = Vec::new();

--- a/sandbox_tests/src/lib.rs
+++ b/sandbox_tests/src/lib.rs
@@ -64,10 +64,12 @@ mod tests {
     use configuration_service::{TxConfigPropose, TxConfigVote, ConfigurationService,
                                 ConfigurationSchema};
     use serde_json::Value;
+
+    #[allow(unused_imports)]
     use blockchain_explorer;
 
     pub fn configuration_sandbox() -> (Sandbox, SandboxState, StoredConfiguration) {
-        let _ = blockchain_explorer::helpers::init_logger();
+        //let _ = blockchain_explorer::helpers::init_logger();
         let sandbox = sandbox_with_services(vec![Box::new(TimestampingService::new()),
                                                  Box::new(ConfigurationService::new())]);
         let sandbox_state = SandboxState::new();
@@ -97,7 +99,6 @@ mod tests {
         use exonum::blockchain::Service;
         use serde_json::Value;
         use serde_json::value::ToJson;
-        let _ = blockchain_explorer::helpers::init_logger();
         let (sandbox, sandbox_state, initial_cfg)  = configuration_sandbox();
         sandbox.assert_state(1, 1);
         add_one_height_with_transactions(&sandbox, &sandbox_state, &[]);


### PR DESCRIPTION
…`let _ = helpers::init_logger();` to enable.